### PR TITLE
LPD-19882 Cannot select Home Folder from linked Asset Library on Document & Media Widget

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
@@ -64,6 +64,14 @@ export default function ResourceSelector({
 						resourceValue: selectedItem[resourceValueKey],
 						showWarning: false,
 					});
+
+					const repositoryIdElement = document.querySelector<
+						HTMLInputElement
+					>(`${portletNamespace}selectedRepositoryId`);
+
+					if (repositoryIdElement) {
+						repositoryIdElement.value = selectedItem.repositoryid;
+					}
 				}
 			},
 			selectEventName: `${portletNamespace}${selectEventName}`,


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-19882)

## Steps

- Go to Control Menu > Applications > Asset Libraries 
- Create one > in the left > Go to Sites section and link it to a site
- Go to Content and Data > Documents and Media > upload a file
- Go to Site Builder > Pages > Create a Content Page
- Add a Documents and Media widget > Go to its configuration
- In Folders Listing > click on select button 
- Go to Sites and Libraries section > Asset Library 
- Click on the Asset Library created and click on Select This Folder 